### PR TITLE
havoc: config: fix include of qcom caf hals in soong namespace

### DIFF
--- a/config/BoardConfigQcom.mk
+++ b/config/BoardConfigQcom.mk
@@ -80,9 +80,9 @@ endif
 endif
 
 PRODUCT_SOONG_NAMESPACES += \
-    hardware/qcom/audio-caf/$(QCOM_HARDWARE_VARIANT) \
-    hardware/qcom/display-caf/$(QCOM_HARDWARE_VARIANT) \
-    hardware/qcom/media-caf/$(QCOM_HARDWARE_VARIANT)
+    hardware/qcom/audio-caf-$(QCOM_HARDWARE_VARIANT) \
+    hardware/qcom/display-caf-$(QCOM_HARDWARE_VARIANT) \
+    hardware/qcom/media-caf-$(QCOM_HARDWARE_VARIANT)
 
 # QCOM HW crypto
 ifeq ($(TARGET_HW_DISK_ENCRYPTION),true)


### PR DESCRIPTION
fixes open issue 