### PR TITLE
vendor: move HAVOC_BASE_VERSION logic to android_build [1/2]

### DIFF
--- a/config/version.mk
+++ b/config/version.mk
@@ -14,7 +14,6 @@ TARGET_PRODUCT_SHORT := $(subst havoc_,,$(HAVOC_BUILD_TYPE))
 
 # Set all versions
 DATE := $(shell date -u +%Y%m%d)
-HAVOC_BASE_VERSION = 2.3
 HAVOC_BUILD_VERSION := Havoc-OS-v$(HAVOC_BASE_VERSION)-$(DATE)-$(HAVOC_BUILD_TYPE)
 HAVOC_DATE := $(shell date -u +%d-%m-%Y)
 HAVOC_VERSION := Havoc-OS-v$(HAVOC_BASE_VERSION)-$(DATE)-$(HAVOC_BUILD)-$(HAVOC_BUILD_TYPE)
@@ -22,7 +21,6 @@ ROM_FINGERPRINT := Havoc-OS/v$(HAVOC_BASE_VERSION)/$(PLATFORM_VERSION)/$(TARGET_
 
 PRODUCT_PROPERTY_OVERRIDES += \
     BUILD_DISPLAY_ID=$(BUILD_ID) \
-    ro.havoc.base.version=$(HAVOC_BASE_VERSION) \
     ro.havoc.build.date=$(HAVOC_DATE) \
     ro.havoc.build.version=$(HAVOC_BUILD_VERSION) \
     ro.havoc.fingerprint=$(ROM_FINGERPRINT) \


### PR DESCRIPTION
* Fixes .json file output of "version" for Treble Devices