### PR TITLE
vendor: add BUILD_RRO_SYSTEM_PACKAGE target

### DIFF
--- a/build/core/system_rro.mk
+++ b/build/core/system_rro.mk
@@ -1,0 +1,28 @@
+# Copyright (C) 2018 The LineageOS Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+LOCAL_IS_RUNTIME_RESOURCE_OVERLAY := true
+
+ifneq ($(LOCAL_SRC_FILES),)
+  $(error runtime resource overlay package should not contain sources)
+endif
+
+ifeq ($(LOCAL_RRO_THEME),)
+  $(error runtime resource overlay package must define \'LOCAL_RRO_THEME\')
+else
+  LOCAL_MODULE_PATH := $(TARGET_OUT)/app/$(LOCAL_RRO_THEME)
+endif
+
+include $(BUILD_SYSTEM)/package.mk
+


### PR DESCRIPTION
Allows to ship rro packages in system instead of vendor

Change-Id: I8822ca477e80297dce477de2d87bd3e74d4cbfb0
Signed-off-by: Joey <joey@lineageos.org>